### PR TITLE
warn package lock - only if package-lock file exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Example usage as CircleCI step:
     docker:
       - image: circleci/node
     steps:
+      - checkout
       - run:
           name: danger
           command: npx @fiverr/dangerfile@2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/dangerfile",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "⚠️ Centralised dangerfile",
   "author": "Fiverr SRE",
   "license": "MIT",
@@ -19,6 +19,7 @@
   },
   "bin": "bin.js",
   "dependencies": {
+    "@does/exist": "^1.1.0",
     "async-execute": "^1.1.0",
     "danger": "^9.2.9"
   },

--- a/src/packageLockUpdateWarn/index.js
+++ b/src/packageLockUpdateWarn/index.js
@@ -1,3 +1,5 @@
+const exist = require('@does/exist');
+
 /**
  * Danger message warning.
  * @constant
@@ -18,8 +20,9 @@ Did you forget to do \`npm i\` before commit?
 const run = async(fileMatch, warn) => {
     const packageJsonFile = fileMatch('package.json');
     const packageLockFile = fileMatch('package-lock.json');
+    const lockFileExists = await exist('package-lock.json');
 
-    if (packageJsonFile.modified && !packageLockFile.modified) {
+    if (packageJsonFile.modified && !packageLockFile.modified && lockFileExists) {
         warn(MESSAGE);
     }
 };

--- a/src/packageLockUpdateWarn/spec.js
+++ b/src/packageLockUpdateWarn/spec.js
@@ -1,16 +1,22 @@
-const {
-    MESSAGE,
-    run
-} = require('.');
+let MESSAGE;
+let run;
 
 describe('packageLockUpdateWarn', () => {
     describe('.run', () => {
         const fileMatch = jest.fn();
         const warn = jest.fn();
 
+        beforeAll(() => {
+            jest.mock('@does/exist', () => jest.fn(() => true));
+           ({ MESSAGE, run } = require('.'));
+        });
         afterEach(() => {
             fileMatch.mockRestore();
             warn.mockRestore();
+            jest.clearAllMocks();
+        });
+        afterAll(() => {
+            jest.unmock('@does/exist');
         });
 
         describe('when package.json is modified', () => {
@@ -56,6 +62,14 @@ describe('packageLockUpdateWarn', () => {
                             expect(warn).toHaveBeenCalledWith(MESSAGE);
                         })
                 );
+
+                test('should not call warn when package-lock does not exist', () => {
+                    require('@does/exist').mockImplementationOnce(jest.fn(() => false));
+                    run(fileMatch, warn)
+                            .then(() => {
+                                expect(warn).not.toHaveBeenCalled();
+                            })
+                });
             });
         });
 

--- a/src/packageLockUpdateWarn/spec.js
+++ b/src/packageLockUpdateWarn/spec.js
@@ -8,7 +8,7 @@ describe('packageLockUpdateWarn', () => {
 
         beforeAll(() => {
             jest.mock('@does/exist', () => jest.fn(() => true));
-           ({ MESSAGE, run } = require('.'));
+            ({ MESSAGE, run } = require('.'));
         });
         afterEach(() => {
             fileMatch.mockRestore();
@@ -66,9 +66,9 @@ describe('packageLockUpdateWarn', () => {
                 test('should not call warn when package-lock does not exist', () => {
                     require('@does/exist').mockImplementationOnce(jest.fn(() => false));
                     run(fileMatch, warn)
-                            .then(() => {
-                                expect(warn).not.toHaveBeenCalled();
-                            })
+                        .then(() => {
+                            expect(warn).not.toHaveBeenCalled();
+                        });
                 });
             });
         });


### PR DESCRIPTION
Packages do not maintain a lock file - which makes this check false positive each time.