### PR TITLE
Tweak unitTestsPresenceWarn test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/dangerfile",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "⚠️ Centralised dangerfile",
   "author": "Fiverr SRE",
   "license": "MIT",

--- a/src/unitTestsPresenceWarn/index.js
+++ b/src/unitTestsPresenceWarn/index.js
@@ -5,7 +5,7 @@
  * @default
  */
 const MESSAGE = `<b>What about unit tests?</b> - <i>
-It seems you did some changes but you did not update/add any unit tests.
+It seems like you made some changes, but you did not update/add any tests.
 </i> 🤔`;
 
 /**
@@ -16,6 +16,16 @@ It seems you did some changes but you did not update/add any unit tests.
 const testsFileFound = (files) =>
     files.some((file) =>
         /(test|spec)/g.test(file)
+    );
+
+/**
+ * Return true if .mjs/.js/ files found.
+ * @param {String[]} files - list of files.
+ * @returns {Boolean}
+ */
+const jsFileFound = (files) =>
+    files.some((file) =>
+        /\.m?js$/g.test(file)
     );
 
 /**
@@ -37,7 +47,7 @@ const run = async(files, warn) => {
         return;
     }
 
-    if (!testsFileFound(files)) {
+    if (!testsFileFound(files) && jsFileFound(files)) {
         warn(MESSAGE);
     }
 };

--- a/src/unitTestsPresenceWarn/spec.js
+++ b/src/unitTestsPresenceWarn/spec.js
@@ -13,7 +13,7 @@ describe('sizeDiffWarn', () => {
             warn.mockRestore();
         });
 
-        describe('when files is undefined', () => {
+        describe('when files are undefined', () => {
             beforeEach(() => {
                 files = undefined;
             });
@@ -53,7 +53,7 @@ describe('sizeDiffWarn', () => {
             );
         });
 
-        describe('when test files found', () => {
+        describe('when test files have been found', () => {
             beforeEach(() => {
                 files = [
                     'blabla.js',
@@ -76,7 +76,7 @@ describe('sizeDiffWarn', () => {
             );
         });
 
-        describe('when test files not found', () => {
+        describe('when test files have not been found and js files were changed', () => {
             beforeEach(() => {
                 files = ['blabla.js'];
             });
@@ -92,6 +92,26 @@ describe('sizeDiffWarn', () => {
                 run(files, warn)
                     .then(() => {
                         expect(warn).toHaveBeenCalledWith(MESSAGE);
+                    })
+            );
+        });
+
+        describe('when test files have not been found, but no js files were changed', () => {
+            beforeEach(() => {
+                files = ['blabla.json'];
+            });
+
+            test('should resolve', () =>
+                run(files, warn)
+                    .then((data) => {
+                        expect(data).toBe(undefined);
+                    })
+            );
+
+            test('should not call warn', () =>
+                run(files, warn)
+                    .then(() => {
+                        expect(warn).not.toHaveBeenCalled();
                     })
             );
         });


### PR DESCRIPTION
Right now, this warning is being triggered no matter which files were changed:
https://github.com/fiverr/translations_hub/pull/57

I think it makes more sense if it only applies if `.js` files were changed ...