### PR TITLE
Update dangerousSetInnerHTMLWarn to create for sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/dangerfile",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "⚠️ Centralised dangerfile",
   "author": "Fiverr SRE",
   "license": "MIT",

--- a/src/dangerousSetInnerHTMLWarn/index.js
+++ b/src/dangerousSetInnerHTMLWarn/index.js
@@ -5,16 +5,16 @@
  * @default
  */
 const MESSAGE = `<b>Security! (XSS)</b> - <i>
-Please make sure you do not introduce any user generated content using *dangerouslySetInnerHTML*.
+Please make sure that any user generated content has been sanitized <b>before</b> using *dangerouslySetInnerHTML*.
 </i> ⛔️`;
 
 /**
- * Return true if detect "dangerouslySetInnerHTML" in str.
+ * Return true if "dangerouslySetInnerHTML" is in string and "createSanitizedMarkup" isn't.
  * @param {String} str
  * @returns {Boolean}
  */
 const dangerouslySetInnerHTMLDetected = (str) =>
-    str && str.includes('dangerouslySetInnerHTML');
+    str && str.includes('dangerouslySetInnerHTML') && !str.includes('createSanitizedMarkup(');
 
 /**
  * Warn if detect "dangerouslySetInnerHTML" added.

--- a/src/dangerousSetInnerHTMLWarn/index.js
+++ b/src/dangerousSetInnerHTMLWarn/index.js
@@ -4,8 +4,8 @@
  * @type {String}
  * @default
  */
-const MESSAGE = `<b>Security! (XSS)</b> - <i>
-Please make sure that any user generated content has been sanitized <b>before</b> using *dangerouslySetInnerHTML*.
+const MESSAGE = `<b>Security! (XSS)</b><br><i>
+Please make sure that any user generated content has been sanitized by using Futile's <a href="https://docs.fiverr-gw.com/@fiverr-private/futile/function/index.html#static-function-createSanitizedMarkup" target="_blank">createSanitizedMarkup</a> method <b>before</b> using dangerouslySetInnerHTML.
 </i> ⛔️`;
 
 /**

--- a/src/dangerousSetInnerHTMLWarn/spec.js
+++ b/src/dangerousSetInnerHTMLWarn/spec.js
@@ -3,14 +3,14 @@ const {
     run
 } = require('.');
 
-const DIFF_CONTAINS_DANGEROUSLY_SET_INNER_HTML= `
+const DIFF_CONTAINS_DANGEROUSLY_SET_INNER_HTML = `
     blabla
     dangerouslySetInnerHTML
     blabla
     blabla
 `;
 
-const DIFF_CONTAINS_DANGEROUSLY_SET_INNER_HTML_SANITIZED= `
+const DIFF_CONTAINS_DANGEROUSLY_SET_INNER_HTML_SANITIZED = `
     blabla
     dangerouslySetInnerHTML={createSanitizedMarkup(string)}
     blabla

--- a/src/dangerousSetInnerHTMLWarn/spec.js
+++ b/src/dangerousSetInnerHTMLWarn/spec.js
@@ -5,7 +5,14 @@ const {
 
 const DIFF_CONTAINS_DANGEROUSLY_SET_INNER_HTML= `
     blabla
-    +  dangerouslySetInnerHTML
+    dangerouslySetInnerHTML
+    blabla
+    blabla
+`;
+
+const DIFF_CONTAINS_DANGEROUSLY_SET_INNER_HTML_SANITIZED= `
+    blabla
+    dangerouslySetInnerHTML={createSanitizedMarkup(string)}
     blabla
     blabla
 `;
@@ -61,7 +68,7 @@ describe('dangerousSetInnerHTMLWarn', () => {
             );
         });
 
-        describe('when a file contain "dangerouslySetInnerHTML"', () => {
+        describe('when a file contains "dangerouslySetInnerHTML" and is not sanitized', () => {
             beforeEach(() => {
                 files = ['a.js'];
                 diffForFile.mockImplementation(() =>
@@ -82,6 +89,31 @@ describe('dangerousSetInnerHTMLWarn', () => {
                 run(files, diffForFile, warn)
                     .then(() => {
                         expect(warn).toHaveBeenCalledWith(MESSAGE);
+                    })
+            );
+        });
+
+        describe('when a file contains "dangerouslySetInnerHTML" and is sanitized', () => {
+            beforeEach(() => {
+                files = ['a.js'];
+                diffForFile.mockImplementation(() =>
+                    Promise.resolve({
+                        after: DIFF_CONTAINS_DANGEROUSLY_SET_INNER_HTML_SANITIZED
+                    })
+                );
+            });
+
+            test('should resolve', () =>
+                run(files, diffForFile, warn)
+                    .then((data) => {
+                        expect(data).toBe(undefined);
+                    })
+            );
+
+            test('should not call warn', () =>
+                run(files, diffForFile, warn)
+                    .then(() => {
+                        expect(warn).not.toHaveBeenCalled();
                     })
             );
         });


### PR DESCRIPTION
Sorry - should have added this to the previous PR.

Seeing that we now have the `createSanitizedMarkup` method in Futile, we should check whether people are using it when they're calling `dangerouslySetInnerHTML`.