### PR TITLE
Ignore lockfile check if it doesn't exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/dangerfile",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "⚠️ Centralised dangerfile",
   "author": "Fiverr SRE",
   "license": "MIT",

--- a/src/packageLockUpdateWarn/index.js
+++ b/src/packageLockUpdateWarn/index.js
@@ -1,3 +1,6 @@
+const { join } = require('path');
+const { existsSync } = require('fs');
+
 /**
  * Danger message warning.
  * @constant
@@ -10,6 +13,16 @@ Did you forget to do \`npm i\` before commit?
 </i> 🔒`;
 
 /**
+ * The package's lockfile file name.
+ * @constant
+ * @type {String}
+ */
+const LOCKFILE_NAME = 'package-lock.json';
+
+const packageRoot = process.cwd();
+const lockfilePath = join(packageRoot, LOCKFILE_NAME);
+
+/**
  * Warn in case package.json was modified and package-lock was not.
  * @param {Function} fileMatch - danger fileMatch.
  * @param {Function} warn - danger warn.
@@ -17,7 +30,11 @@ Did you forget to do \`npm i\` before commit?
  */
 const run = async(fileMatch, warn) => {
     const packageJsonFile = fileMatch('package.json');
-    const packageLockFile = fileMatch('package-lock.json');
+    const packageLockFile = fileMatch(LOCKFILE_NAME);
+
+    if (!existsSync(lockfilePath)) {
+        return;
+    }
 
     if (packageJsonFile.modified && !packageLockFile.modified) {
         warn(MESSAGE);

--- a/src/packageLockUpdateWarn/spec.js
+++ b/src/packageLockUpdateWarn/spec.js
@@ -1,3 +1,7 @@
+const fs = require('fs');
+
+jest.mock('fs');
+
 const {
     MESSAGE,
     run
@@ -19,6 +23,32 @@ describe('packageLockUpdateWarn', () => {
                     fileMatch
                         .mockImplementationOnce(() => ({ modified: true }))
                         .mockImplementationOnce(() => ({ modified: true }));
+
+                    fs.existsSync.mockReturnValue(true);
+                });
+
+                test('should resolve', () =>
+                    run(fileMatch, warn)
+                        .then((data) => {
+                            expect(data).toBe(undefined);
+                        })
+                );
+
+                test('should not call warn', () =>
+                    run(fileMatch, warn)
+                        .then(() => {
+                            expect(warn).not.toHaveBeenCalled();
+                        })
+                );
+            });
+
+            describe('when package-lock.json doesn\'t exist', () => {
+                beforeEach(() => {
+                    fileMatch
+                        .mockImplementationOnce(() => ({ modified: true }))
+                        .mockImplementationOnce(() => ({ modified: false }));
+
+                    fs.existsSync.mockReturnValue(false);
                 });
 
                 test('should resolve', () =>
@@ -41,6 +71,8 @@ describe('packageLockUpdateWarn', () => {
                     fileMatch
                         .mockImplementationOnce(() => ({ modified: true }))
                         .mockImplementationOnce(() => ({ modified: false }));
+
+                    fs.existsSync.mockReturnValue(true);
                 });
 
                 test('should resolve', () =>


### PR DESCRIPTION
This check doesn't make sense for repos that don't have an npm lockfile.