### PR TITLE
[FEATURE] add `fitIconsUsageWarn`

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -35,6 +35,7 @@ const packageLockUpdateWarn = require('./src/packageLockUpdateWarn');
 const sizeDiffWarn = require('./src/sizeDiffWarn');
 const unitTestsPresenceWarn = require('./src/unitTestsPresenceWarn');
 const versionBumpWarn = require('./src/versionBumpWarn');
+const fitIconsUsageWarn = require('./src/fitIconsUsageWarn');
 
 schedule(bindingPryPresenceFail.run(changedFiles, diffForFile, fail));
 schedule(changelog.run(diffForFile, exist, warn));
@@ -46,3 +47,4 @@ schedule(packageLockUpdateWarn.run(fileMatch, warn));
 schedule(sizeDiffWarn.run(modifiedFiles, diffForFile, warn));
 schedule(unitTestsPresenceWarn.run(changedFiles, warn));
 schedule(versionBumpWarn.run(fileContents, diffForFile, exist, warn));
+schedule(fitIconsUsageWarn.run(changedFiles, diffForFile, warn));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/dangerfile",
-  "version": "2.2.0-rc",
+  "version": "2.2.0",
   "description": "⚠️ Centralised dangerfile",
   "author": "Fiverr SRE",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/dangerfile",
-  "version": "2.1.13",
+  "version": "2.2.0-rc",
   "description": "⚠️ Centralised dangerfile",
   "author": "Fiverr SRE",
   "license": "MIT",

--- a/src/fitIconsUsageWarn/index.js
+++ b/src/fitIconsUsageWarn/index.js
@@ -1,0 +1,40 @@
+/**
+ * Danger message warning.
+ * @constant
+ * @type {String}
+ * @default
+ */
+const MESSAGE = `<b>Incorrect Usage of Icons</b><br><i>
+ The icons have been moved to <a href="https://github.com/fiverr/blocks/tree/master/packages/icons" target="_blank">their own package</a>, please install the "@fiverr-private/icons" package, and replace "@fiverr-private/fit/icons" imports with "@fiverr-private/icons".
+ </i> ⛔️`;
+
+/**
+  * Detects whether the diff has any usage of "@fiverr-private/fit/icons".
+  * @param {String} str
+  * @returns {Boolean}
+  */
+const fitIconsUsageDetected = (str) =>
+    (str || '').includes('@fiverr-private/fit/icons');
+
+/**
+  * Warn if detect "@fiverr-private/fit/icons" added.
+  * @param {String[]} files - list of modified files.
+  * @param {Function} diffForFile - danger diffForFile.
+  * @param {Function} warn - danger warn.
+  * @returns {Promise<undefined>}
+  */
+const run = async(files, diffForFile, warn) => {
+    for (const file of files || []) {
+        const { after } = await diffForFile(file);
+
+        if (fitIconsUsageDetected(after)) {
+            warn(MESSAGE);
+            return;
+        }
+    }
+};
+
+module.exports = {
+    MESSAGE,
+    run
+};

--- a/src/fitIconsUsageWarn/spec.js
+++ b/src/fitIconsUsageWarn/spec.js
@@ -1,0 +1,68 @@
+const {
+    MESSAGE,
+    run
+} = require('.');
+
+const DIFF_CONTAINS_FIT_ICONS = `
+    import {l_comment} from '@fiverr-private/fit/icons';
+    blabla
+    blabla
+`;
+
+const DIFF_DOES_NOT_CONTAIN_FIT_ICONS = `
+    import {Icon} from '@fiverr-private/fit';
+    import {l_comment} from '@fiverr-private/icons';
+    blabla
+    blabla
+`;
+
+const files = ['a.js'];
+
+describe('fitIconsUsageWarn', () => {
+    let diffForFile = jest.fn();
+    let warn = jest.fn();
+
+    beforeEach(() => {
+        diffForFile = jest.fn();
+        warn = jest.fn();
+    });
+
+    it('should not warn when has no files', async() => {
+        await run(undefined, diffForFile, warn)
+            .then(() => {
+                expect(warn).not.toHaveBeenCalled();
+            });
+    });
+
+    it('should not warn when has no changes', async() => {
+        setDiff(undefined);
+        await run(files, diffForFile, warn)
+            .then(() => {
+                expect(warn).not.toHaveBeenCalled();
+            });
+    });
+
+    it('should not warn when has no fit icons usage', async() => {
+        setDiff(DIFF_DOES_NOT_CONTAIN_FIT_ICONS);
+        await run(files, diffForFile, warn)
+            .then(() => {
+                expect(warn).not.toHaveBeenCalled();
+            });
+    });
+
+    it('should warn when detected fit icons usage', async() => {
+        setDiff(DIFF_CONTAINS_FIT_ICONS);
+        await run(files, diffForFile, warn)
+            .then(() => {
+                expect(warn).toHaveBeenCalledWith(MESSAGE);
+            });
+    });
+
+    function setDiff(after) {
+        diffForFile.mockImplementation(() =>
+            Promise.resolve({
+                after
+            })
+        );
+    }
+});


### PR DESCRIPTION
Will warn when using @fiverr-private/fit/icons.

![Example](https://user-images.githubusercontent.com/80754092/120918793-e7cd2800-c6be-11eb-9a46-ca3f79cdd447.png)

Example:https://github.com/fiverr/test_perseus/pull/49
