### PR TITLE
[Danger] Warn when using raw colors instead of color variables

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -36,6 +36,7 @@ const sizeDiffWarn = require('./src/sizeDiffWarn');
 const unitTestsPresenceWarn = require('./src/unitTestsPresenceWarn');
 const versionBumpWarn = require('./src/versionBumpWarn');
 const fitIconsUsageWarn = require('./src/fitIconsUsageWarn');
+const rawColorsWarn = require('./src/rawColorsWarn');
 
 schedule(bindingPryPresenceFail.run(changedFiles, diffForFile, fail));
 schedule(changelog.run(diffForFile, exist, warn));
@@ -48,3 +49,4 @@ schedule(sizeDiffWarn.run(modifiedFiles, diffForFile, warn));
 schedule(unitTestsPresenceWarn.run(changedFiles, warn));
 schedule(versionBumpWarn.run(fileContents, diffForFile, exist, warn));
 schedule(fitIconsUsageWarn.run(changedFiles, diffForFile, warn));
+schedule(rawColorsWarn.run(changedFiles, diffForFile, warn));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/dangerfile",
-  "version": "2.2.0",
+  "version": "2.3.0-rc",
   "description": "⚠️ Centralised dangerfile",
   "author": "Fiverr SRE",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/dangerfile",
-  "version": "2.3.0-rc",
+  "version": "2.3.0",
   "description": "⚠️ Centralised dangerfile",
   "author": "Fiverr SRE",
   "license": "MIT",

--- a/src/rawColorsWarn/index.js
+++ b/src/rawColorsWarn/index.js
@@ -1,0 +1,62 @@
+/**
+ * Danger message warning.
+ * @constant
+ * @type {String}
+ * @default
+ */
+const MESSAGE = `<b>Raw Colors Detected</b><br><i>
+ Please do not use raw colors directly (#XXX or rgb(X, X, X)).
+ Instead, import colors from '@fiverr-private/sass'.
+
+ In scss: 
+    @import '~@fiverr-private/sass/helpers/index'; 
+    ...
+    h1 {
+        color: color($blue, 500);
+    }
+
+ In JS/TS:
+    import { blue_500 } from '@fiverr-private/sass/helpers/index';
+ </i> ⛔️`;
+
+/**
+  * Warn if detect "@fiverr-private/fit/icons" added.
+  * @param {String[]} files - list of modified files.
+  * @param {Function} diffForFile - danger diffForFile.
+  * @param {Function} warn - danger warn.
+  * @returns {Promise<undefined>}
+  */
+const run = async(files, diffForFile, warn) => {
+    for (const file of files || []) {
+        if (shouldSkipFile(file)) {
+            continue;
+        }
+        const { after } = await diffForFile(file);
+
+        if (rawColorsDetected(after)) {
+            warn(MESSAGE);
+            return;
+        }
+    }
+};
+
+/**
+  * Determines if the current file should be skipped, allowing raw colors in it.
+  * @param {string} file
+  * @returns {Boolean}
+  */
+const shouldSkipFile = (file) =>
+    (file || '').match(/story|stories|doc|.md|spec|test/);
+
+/**
+  * Detects whether the diff has any raw colros.
+  * @param {String} str
+  * @returns {Boolean}
+  */
+const rawColorsDetected = (str) =>
+    (str || '').match(/#[a-zA-Z0-9]{3,6}|rgba?\([0-9, ]+?\)/);
+
+module.exports = {
+    MESSAGE,
+    run
+};

--- a/src/rawColorsWarn/spec.js
+++ b/src/rawColorsWarn/spec.js
@@ -1,0 +1,86 @@
+const {
+    MESSAGE,
+    run
+} = require('.');
+
+const DIFF_RAW_COLOR_HASH = `
+    const myColor = #cccddd;
+`;
+
+const DIFF_RAW_COLOR_RGB = `
+    const myColor = "rgb(1, 2, 3)";
+`;
+
+const DIFF_VARIABLE_COLOR = `
+    import { blue_500 } from '@fiverr-private/sass/helpers/index';
+
+    const myColor = blue_500;
+`;
+
+const FILES_TO_SKIP = ['story.js'];
+const FILES = ['myfile.js'];
+
+describe('rawColorsWarn', () => {
+    let diffForFile = jest.fn();
+    let warn = jest.fn();
+
+    beforeEach(() => {
+        diffForFile = jest.fn();
+        warn = jest.fn();
+    });
+
+    it('should not warn when has no files', async() => {
+        await run(undefined, diffForFile, warn)
+            .then(() => {
+                expect(warn).not.toHaveBeenCalled();
+            });
+    });
+
+    it('should not warn when has no changes', async() => {
+        setDiff(undefined);
+        await run(FILES, diffForFile, warn)
+            .then(() => {
+                expect(warn).not.toHaveBeenCalled();
+            });
+    });
+
+    it('should not warn when file is skippable', async() => {
+        setDiff(DIFF_RAW_COLOR_HASH);
+        await run(FILES_TO_SKIP, diffForFile, warn)
+            .then(() => {
+                expect(warn).not.toHaveBeenCalled();
+            });
+    });
+
+    it('should warn when using hash colors', async() => {
+        setDiff(DIFF_RAW_COLOR_HASH);
+        await run(FILES, diffForFile, warn)
+            .then(() => {
+                expect(warn).toHaveBeenCalledWith(MESSAGE);
+            });
+    });
+
+    it('should warn when using RGB colors', async() => {
+        setDiff(DIFF_RAW_COLOR_RGB);
+        await run(FILES, diffForFile, warn)
+            .then(() => {
+                expect(warn).toHaveBeenCalledWith(MESSAGE);
+            });
+    });
+
+    it('should not warn when using variable colors', async() => {
+        setDiff(DIFF_VARIABLE_COLOR);
+        await run(FILES, diffForFile, warn)
+            .then(() => {
+                expect(warn).not.toHaveBeenCalled();
+            });
+    });
+
+    function setDiff(after) {
+        diffForFile.mockImplementation(() =>
+            Promise.resolve({
+                after
+            })
+        );
+    }
+});


### PR DESCRIPTION
Now that the palette colors are available in both JS and SCSS, there should be no reason to use hardcoded colors.
This will warn to increase the awareness, and at some point, this will be changed to an error.

Example:
https://github.com/fiverr/test_perseus/pull/53
![image](https://user-images.githubusercontent.com/80754092/123083744-0c4c3280-d429-11eb-9343-dfae37f7b7d3.png)

This PR will wait for https://github.com/fiverr/anthill/pull/413 to be out, to ensure sass is actually ready to use in perseuses and packages.