### PR TITLE
[FEAT] Add textCapitalizationFail

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -37,11 +37,13 @@ const unitTestsPresenceWarn = require('./src/unitTestsPresenceWarn');
 const versionBumpWarn = require('./src/versionBumpWarn');
 const fitIconsUsageWarn = require('./src/fitIconsUsageWarn');
 const textCapitalizationFail = require('./src/textCapitalizationFail');
+const textCapitalizationWarn = require('./src/textCapitalizationWarn');
 
 schedule(bindingPryPresenceFail.run(changedFiles, diffForFile, fail));
 schedule(changelog.run(diffForFile, exist, warn));
 schedule(rcPresenceFail.run(changedFiles, diffForFile, fail));
 schedule(textCapitalizationFail.run(changedFiles, diffForFile, fail));
+schedule(textCapitalizationWarn.run(changedFiles, diffForFile, warn));
 schedule(dangerousSetInnerHTMLWarn.run(changedFiles, diffForFile, warn));
 schedule(descriptionPresenceFail.run(body, fail));
 schedule(gemfileLockUpdateWarn.run(fileMatch, warn));

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -36,10 +36,12 @@ const sizeDiffWarn = require('./src/sizeDiffWarn');
 const unitTestsPresenceWarn = require('./src/unitTestsPresenceWarn');
 const versionBumpWarn = require('./src/versionBumpWarn');
 const fitIconsUsageWarn = require('./src/fitIconsUsageWarn');
+const textCapitalizationFail = require('./src/textCapitalizationFail');
 
 schedule(bindingPryPresenceFail.run(changedFiles, diffForFile, fail));
 schedule(changelog.run(diffForFile, exist, warn));
 schedule(rcPresenceFail.run(changedFiles, diffForFile, fail));
+schedule(textCapitalizationFail.run(changedFiles, diffForFile, fail));
 schedule(dangerousSetInnerHTMLWarn.run(changedFiles, diffForFile, warn));
 schedule(descriptionPresenceFail.run(body, fail));
 schedule(gemfileLockUpdateWarn.run(fileMatch, warn));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/dangerfile",
-  "version": "2.2.1",
+  "version": "2.3.0-rc",
   "description": "⚠️ Centralised dangerfile",
   "author": "Fiverr SRE",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/dangerfile",
-  "version": "2.3.0-rc",
+  "version": "2.3.0",
   "description": "⚠️ Centralised dangerfile",
   "author": "Fiverr SRE",
   "license": "MIT",

--- a/src/textCapitalizationFail/index.js
+++ b/src/textCapitalizationFail/index.js
@@ -5,8 +5,15 @@
  * @default
  */
 const MESSAGE = `<b>Cannot merge release candidate!</b> - <i>
-Please do not use "text-transform: capitalize" before merging to master because this violates localization rules.
-</i> 🧐`;
+Please do not use "text-transform: capitalize" because this violates localization rules.
+</i> 🌐`;
+
+/**
+ * Return true if .css/.scss/.js/.ts files found.
+ * @param {String} file - modified file.
+ * @returns {Boolean}
+ */
+const isEligibleFile = (file) =>/\.(js|ts|scss|css)$/g.test(file);
 
 /**
  * Return true if detect "text-transform: capitalize" in the modified files.
@@ -25,11 +32,13 @@ const textCapitalizationDetected = (str) =>
  */
 const run = async(files = [], diffForFile, fail) => {
     for (const file of files) {
-        const { after } = await diffForFile(file);
+        if (isEligibleFile(file)) {
+            const { after } = await diffForFile(file);
 
-        if (textCapitalizationDetected(after)) {
-            fail(MESSAGE);
-            return;
+            if (textCapitalizationDetected(after)) {
+                fail(MESSAGE);
+                return;
+            }
         }
     }
 };

--- a/src/textCapitalizationFail/index.js
+++ b/src/textCapitalizationFail/index.js
@@ -5,7 +5,7 @@
  * @default
  */
 const MESSAGE = `<b>Cannot merge release candidate!</b> - <i>
-Please do not use "text-transform: capitalize" because this violates localization rules.
+Please do not use "text-transform: capitalize" OR "capitalize" method from '@fiverr-private/futile' because this violates localization rules.
 </i> 🌐`;
 
 /**
@@ -21,10 +21,10 @@ const isEligibleFile = (file) => (/\.(js|ts|scss|css)$/g.test(file) && !/(test|s
  * @returns {Boolean}
  */
 const textCapitalizationDetected = (str) =>
-    str && /text-transform:\s+capitalize/.test(str);
+    str && (/text-transform:\s+capitalize/.test(str) || /capitalize.+futile/.test(str));
 
 /**
- * Fail if detect "text-transform: capitalize" added to a modified file.
+ * Fail if detect "text-transform: capitalize" or consumption of "capitalize" from futile added to a modified file.
  * @param {String[]} files - list of modified files.
  * @param {Function} diffForFile - danger diffForFile.
  * @param {Function} fail - danger fail.

--- a/src/textCapitalizationFail/index.js
+++ b/src/textCapitalizationFail/index.js
@@ -9,11 +9,11 @@ Please do not use "text-transform: capitalize" because this violates localizatio
 </i> 🌐`;
 
 /**
- * Return true if .css/.scss/.js/.ts files found.
+ * Return true if .css/.scss/.js/.ts files found and it's not a test
  * @param {String} file - modified file.
  * @returns {Boolean}
  */
-const isEligibleFile = (file) =>/\.(js|ts|scss|css)$/g.test(file);
+const isEligibleFile = (file) => (/\.(js|ts|scss|css)$/g.test(file) && !/(test|spec)/g.test(file));
 
 /**
  * Return true if detect "text-transform: capitalize" in the modified files.

--- a/src/textCapitalizationFail/index.js
+++ b/src/textCapitalizationFail/index.js
@@ -1,0 +1,40 @@
+/**
+ * Danger message failure.
+ * @constant
+ * @type {String}
+ * @default
+ */
+const MESSAGE = `<b>Cannot merge release candidate!</b> - <i>
+Please do not use "text-transform: capitalize" before merging to master because this violates localization rules.
+</i> 🧐`;
+
+/**
+ * Return true if detect "text-transform: capitalize" in the modified files.
+ * @param {String} str
+ * @returns {Boolean}
+ */
+const textCapitalizationDetected = (str) =>
+    str && /text-transform:\s+capitalize/.test(str);
+
+/**
+ * Fail if detect "text-transform: capitalize" added to a modified file.
+ * @param {String[]} files - list of modified files.
+ * @param {Function} diffForFile - danger diffForFile.
+ * @param {Function} fail - danger fail.
+ * @returns {Promise<undefined>}
+ */
+const run = async(files = [], diffForFile, fail) => {
+    for (const file of files) {
+        const { after } = await diffForFile(file);
+
+        if (textCapitalizationDetected(after)) {
+            fail(MESSAGE);
+            return;
+        }
+    }
+};
+
+module.exports = {
+    MESSAGE,
+    run
+};

--- a/src/textCapitalizationFail/index.js
+++ b/src/textCapitalizationFail/index.js
@@ -5,7 +5,7 @@
  * @default
  */
 const MESSAGE = `<b>Cannot merge release candidate!</b> - <i>
-Please do not use "text-transform: capitalize" OR "capitalize" method from '@fiverr-private/futile' because this violates localization rules.
+Please do not use "text-transform: capitalize" because this violates localization rules.
 </i> 🌐`;
 
 /**
@@ -21,7 +21,7 @@ const isEligibleFile = (file) => (/\.(js|ts|scss|css)$/g.test(file) && !/(test|s
  * @returns {Boolean}
  */
 const textCapitalizationDetected = (str) =>
-    str && (/text-transform:\s+capitalize/.test(str) || /capitalize.+futile/.test(str));
+    str && (/text(-t|T)ransform:\s+capitalize/.test(str));
 
 /**
  * Fail if detect "text-transform: capitalize" or consumption of "capitalize" from futile added to a modified file.

--- a/src/textCapitalizationFail/spec.js
+++ b/src/textCapitalizationFail/spec.js
@@ -161,7 +161,32 @@ describe('rcPresenceFail', () => {
             );
         });
 
-        describe('when another file contains "-rc"', () => {
+        describe('when spec file contains "text-transform: capitalize"', () => {
+            beforeEach(() => {
+                files = ['spec.js'];
+                diffForFile.mockImplementation(() =>
+                    Promise.resolve({
+                        after: DIFF_CONTAINS_RC
+                    })
+                );
+            });
+
+            test('should resolve', () =>
+                run(files, diffForFile, fail)
+                    .then((data) => {
+                        expect(data).toBe(undefined);
+                    })
+            );
+
+            test('should not call fail', () =>
+                run(files, diffForFile, fail)
+                    .then(() => {
+                        expect(fail).not.toHaveBeenCalled();
+                    })
+            );
+        });
+
+        describe('when another file contains "text-transform: capitalize"', () => {
             beforeEach(() => {
                 files = ['a.json'];
                 diffForFile.mockImplementation(() =>

--- a/src/textCapitalizationFail/spec.js
+++ b/src/textCapitalizationFail/spec.js
@@ -10,7 +10,7 @@ const DIFF_CONTAINS_RC= `
     blabla
 `;
 
-describe('rcPresenceFail', () => {
+describe('textCapitalizationFail', () => {
     describe('.run', () => {
         const diffForFile = jest.fn();
         const fail = jest.fn();

--- a/src/textCapitalizationFail/spec.js
+++ b/src/textCapitalizationFail/spec.js
@@ -1,0 +1,189 @@
+const {
+    MESSAGE,
+    run
+} = require('.');
+
+const DIFF_CONTAINS_RC= `
+    blabla
+    +  "text-transform: capitalize"
+    blabla
+    blabla
+`;
+
+describe('rcPresenceFail', () => {
+    describe('.run', () => {
+        const diffForFile = jest.fn();
+        const fail = jest.fn();
+
+        let files;
+
+        afterEach(() => {
+            fail.mockRestore();
+        });
+
+        describe('when files are undefined', () => {
+            beforeEach(() => {
+                files = undefined;
+            });
+
+            test('should resolve', () =>
+                run(files, diffForFile, fail)
+                    .then((data) => {
+                        expect(data).toBe(undefined);
+                    })
+            );
+
+            test('should not call fail', () =>
+                run(files, diffForFile, fail)
+                    .then(() => {
+                        expect(fail).not.toHaveBeenCalled();
+                    })
+            );
+        });
+
+        describe('when files are an empty array', () => {
+            beforeEach(() => {
+                files = [];
+            });
+
+            test('should resolve', () =>
+                run(files, diffForFile, fail)
+                    .then((data) => {
+                        expect(data).toBe(undefined);
+                    })
+            );
+
+            test('should not call fail', () =>
+                run(files, diffForFile, fail)
+                    .then(() => {
+                        expect(fail).not.toHaveBeenCalled();
+                    })
+            );
+        });
+
+        describe('when js file contains "text-transform: capitalize"', () => {
+            beforeEach(() => {
+                files = ['a.js', 'package.json'];
+                diffForFile.mockImplementation(() =>
+                    Promise.resolve({
+                        after: DIFF_CONTAINS_RC
+                    })
+                );
+            });
+
+            test('should resolve', () =>
+                run(files, diffForFile, fail)
+                    .then((data) => {
+                        expect(data).toBe(undefined);
+                    })
+            );
+
+            test('should call fail with correct message', () =>
+                run(files, diffForFile, fail)
+                    .then(() => {
+                        expect(fail).toHaveBeenCalledWith(MESSAGE);
+                    })
+            );
+        });
+
+        describe('when ts file contains "text-transform: capitalize"', () => {
+            beforeEach(() => {
+                files = ['a.ts', 'package.json'];
+                diffForFile.mockImplementation(() =>
+                    Promise.resolve({
+                        after: DIFF_CONTAINS_RC
+                    })
+                );
+            });
+
+            test('should resolve', () =>
+                run(files, diffForFile, fail)
+                    .then((data) => {
+                        expect(data).toBe(undefined);
+                    })
+            );
+
+            test('should call fail with correct message', () =>
+                run(files, diffForFile, fail)
+                    .then(() => {
+                        expect(fail).toHaveBeenCalledWith(MESSAGE);
+                    })
+            );
+        });
+
+        describe('when css file contains "text-transform: capitalize"', () => {
+            beforeEach(() => {
+                files = ['a.css', 'package.json'];
+                diffForFile.mockImplementation(() =>
+                    Promise.resolve({
+                        after: DIFF_CONTAINS_RC
+                    })
+                );
+            });
+
+            test('should resolve', () =>
+                run(files, diffForFile, fail)
+                    .then((data) => {
+                        expect(data).toBe(undefined);
+                    })
+            );
+
+            test('should call fail with correct message', () =>
+                run(files, diffForFile, fail)
+                    .then(() => {
+                        expect(fail).toHaveBeenCalledWith(MESSAGE);
+                    })
+            );
+        });
+
+        describe('when scss file contains "text-transform: capitalize"', () => {
+            beforeEach(() => {
+                files = ['a.scss', 'package.json'];
+                diffForFile.mockImplementation(() =>
+                    Promise.resolve({
+                        after: DIFF_CONTAINS_RC
+                    })
+                );
+            });
+
+            test('should resolve', () =>
+                run(files, diffForFile, fail)
+                    .then((data) => {
+                        expect(data).toBe(undefined);
+                    })
+            );
+
+            test('should call fail with correct message', () =>
+                run(files, diffForFile, fail)
+                    .then(() => {
+                        expect(fail).toHaveBeenCalledWith(MESSAGE);
+                    })
+            );
+        });
+
+        describe('when another file contains "-rc"', () => {
+            beforeEach(() => {
+                files = ['a.json'];
+                diffForFile.mockImplementation(() =>
+                    Promise.resolve({
+                        after: DIFF_CONTAINS_RC
+                    })
+                );
+            });
+
+            test('should resolve', () =>
+                run(files, diffForFile, fail)
+                    .then((data) => {
+                        expect(data).toBe(undefined);
+                    })
+            );
+
+            test('should not call fail', () =>
+                run(files, diffForFile, fail)
+                    .then(() => {
+                        expect(fail).not.toHaveBeenCalled();
+                    })
+            );
+        });
+    });
+});

--- a/src/textCapitalizationFail/spec.js
+++ b/src/textCapitalizationFail/spec.js
@@ -3,9 +3,16 @@ const {
     run
 } = require('.');
 
-const DIFF_CONTAINS_RC= `
+const DIFF_CONTAINS_TEXT_TRANSFORM = `
     blabla
     +  "text-transform: capitalize"
+    blabla
+    blabla
+`;
+
+const DIFF_CONTAINS_FUTILE_CAPITALIZE = `
+    blabla
+    +  "import { capitalize } from '@fiverr-private/futile"
     blabla
     blabla
 `;
@@ -61,12 +68,37 @@ describe('textCapitalizationFail', () => {
             );
         });
 
+        describe('when js file contains consumption of futile capitalize', () => {
+            beforeEach(() => {
+                files = ['a.js', 'package.json'];
+                diffForFile.mockImplementation(() =>
+                    Promise.resolve({
+                        after: DIFF_CONTAINS_FUTILE_CAPITALIZE
+                    })
+                );
+            });
+
+            test('should resolve', () =>
+                run(files, diffForFile, fail)
+                    .then((data) => {
+                        expect(data).toBe(undefined);
+                    })
+            );
+
+            test('should call fail with correct message', () =>
+                run(files, diffForFile, fail)
+                    .then(() => {
+                        expect(fail).toHaveBeenCalledWith(MESSAGE);
+                    })
+            );
+        });
+
         describe('when js file contains "text-transform: capitalize"', () => {
             beforeEach(() => {
                 files = ['a.js', 'package.json'];
                 diffForFile.mockImplementation(() =>
                     Promise.resolve({
-                        after: DIFF_CONTAINS_RC
+                        after: DIFF_CONTAINS_TEXT_TRANSFORM
                     })
                 );
             });
@@ -91,7 +123,7 @@ describe('textCapitalizationFail', () => {
                 files = ['a.ts', 'package.json'];
                 diffForFile.mockImplementation(() =>
                     Promise.resolve({
-                        after: DIFF_CONTAINS_RC
+                        after: DIFF_CONTAINS_TEXT_TRANSFORM
                     })
                 );
             });
@@ -116,7 +148,7 @@ describe('textCapitalizationFail', () => {
                 files = ['a.css', 'package.json'];
                 diffForFile.mockImplementation(() =>
                     Promise.resolve({
-                        after: DIFF_CONTAINS_RC
+                        after: DIFF_CONTAINS_TEXT_TRANSFORM
                     })
                 );
             });
@@ -141,7 +173,7 @@ describe('textCapitalizationFail', () => {
                 files = ['a.scss', 'package.json'];
                 diffForFile.mockImplementation(() =>
                     Promise.resolve({
-                        after: DIFF_CONTAINS_RC
+                        after: DIFF_CONTAINS_TEXT_TRANSFORM
                     })
                 );
             });
@@ -166,7 +198,7 @@ describe('textCapitalizationFail', () => {
                 files = ['spec.js'];
                 diffForFile.mockImplementation(() =>
                     Promise.resolve({
-                        after: DIFF_CONTAINS_RC
+                        after: DIFF_CONTAINS_TEXT_TRANSFORM
                     })
                 );
             });
@@ -191,7 +223,7 @@ describe('textCapitalizationFail', () => {
                 files = ['a.json'];
                 diffForFile.mockImplementation(() =>
                     Promise.resolve({
-                        after: DIFF_CONTAINS_RC
+                        after: DIFF_CONTAINS_TEXT_TRANSFORM
                     })
                 );
             });

--- a/src/textCapitalizationWarn/index.js
+++ b/src/textCapitalizationWarn/index.js
@@ -1,0 +1,49 @@
+/**
+ * Danger message warning.
+ * @constant
+ * @type {String}
+ * @default
+ */
+const MESSAGE = `<b>Capitalize method</b> - <i>
+Please make sure you are not violating any localization rule when consuming "capitalize" method from "futile" or "lodash".
+</i> 🌐`;
+
+/**
+ * Return true if .css/.scss/.js/.ts files found and it's not a test
+ * @param {String} file - modified file.
+ * @returns {Boolean}
+ */
+const isEligibleFile = (file) => (/\.(js|ts)$/g.test(file) && !/(test|spec)/g.test(file));
+
+/**
+ * Return true if detect consumption of capitalize from futile or lodash in the modified files.
+ * @param {String} str
+ * @returns {Boolean}
+ */
+const capitalizeMethodDetected = (str) =>
+    str && (/capitalize.+(futile|lodash)/.test(str));
+
+/**
+ * Warn if detect consumption of "capitalize" from futile or lodash added to a modified file.
+ * @param {String[]} files - list of modified files.
+ * @param {Function} diffForFile - danger diffForFile.
+ * @param {Function} warn - danger warn.
+ * @returns {Promise<undefined>}
+ */
+const run = async(files = [], diffForFile, warn) => {
+    for (const file of files) {
+        if (isEligibleFile(file)) {
+            const { after } = await diffForFile(file);
+
+            if (capitalizeMethodDetected(after)) {
+                warn(MESSAGE);
+                return;
+            }
+        }
+    }
+};
+
+module.exports = {
+    MESSAGE,
+    run
+};

--- a/src/textCapitalizationWarn/spec.js
+++ b/src/textCapitalizationWarn/spec.js
@@ -5,14 +5,14 @@ const {
 
 const DIFF_CONTAINS_FUTILE_CAPITALIZE = `
     blabla
-    +  "import { capitalize } from '@fiverr-private/futile"
+    +  "import { capitalize } from '@fiverr-private/futile'"
     blabla
     blabla
 `;
 
 const DIFF_CONTAINS_LODASH_CAPITALIZE = `
     blabla
-    +  "import { capitalize } from '@fiverr-private/futile"
+    +  "import { capitalize } from 'lodash'"
     blabla
     blabla
 `;

--- a/src/textCapitalizationWarn/spec.js
+++ b/src/textCapitalizationWarn/spec.js
@@ -3,22 +3,29 @@ const {
     run
 } = require('.');
 
-const DIFF_CONTAINS_TEXT_TRANSFORM = `
+const DIFF_CONTAINS_FUTILE_CAPITALIZE = `
     blabla
-    +  "text-transform: capitalize"
+    +  "import { capitalize } from '@fiverr-private/futile"
     blabla
     blabla
 `;
 
-describe('textCapitalizationFail', () => {
+const DIFF_CONTAINS_LODASH_CAPITALIZE = `
+    blabla
+    +  "import { capitalize } from '@fiverr-private/futile"
+    blabla
+    blabla
+`;
+
+describe('textCapitalizationWarn', () => {
     describe('.run', () => {
         const diffForFile = jest.fn();
-        const fail = jest.fn();
+        const warn = jest.fn();
 
         let files;
 
         afterEach(() => {
-            fail.mockRestore();
+            warn.mockRestore();
         });
 
         describe('when files are undefined', () => {
@@ -27,16 +34,16 @@ describe('textCapitalizationFail', () => {
             });
 
             test('should resolve', () =>
-                run(files, diffForFile, fail)
+                run(files, diffForFile, warn)
                     .then((data) => {
                         expect(data).toBe(undefined);
                     })
             );
 
-            test('should not call fail', () =>
-                run(files, diffForFile, fail)
+            test('should not call warn', () =>
+                run(files, diffForFile, warn)
                     .then(() => {
-                        expect(fail).not.toHaveBeenCalled();
+                        expect(warn).not.toHaveBeenCalled();
                     })
             );
         });
@@ -47,166 +54,166 @@ describe('textCapitalizationFail', () => {
             });
 
             test('should resolve', () =>
-                run(files, diffForFile, fail)
+                run(files, diffForFile, warn)
                     .then((data) => {
                         expect(data).toBe(undefined);
                     })
             );
 
-            test('should not call fail', () =>
-                run(files, diffForFile, fail)
+            test('should not call warn', () =>
+                run(files, diffForFile, warn)
                     .then(() => {
-                        expect(fail).not.toHaveBeenCalled();
+                        expect(warn).not.toHaveBeenCalled();
                     })
             );
         });
 
-        describe('when js file contains "text-transform: capitalize"', () => {
+        describe('when js file contains consumption of futile capitalize', () => {
             beforeEach(() => {
                 files = ['a.js', 'package.json'];
                 diffForFile.mockImplementation(() =>
                     Promise.resolve({
-                        after: DIFF_CONTAINS_TEXT_TRANSFORM
+                        after: DIFF_CONTAINS_FUTILE_CAPITALIZE
                     })
                 );
             });
 
             test('should resolve', () =>
-                run(files, diffForFile, fail)
+                run(files, diffForFile, warn)
                     .then((data) => {
                         expect(data).toBe(undefined);
                     })
             );
 
-            test('should call fail with correct message', () =>
-                run(files, diffForFile, fail)
+            test('should call warn with correct message', () =>
+                run(files, diffForFile, warn)
                     .then(() => {
-                        expect(fail).toHaveBeenCalledWith(MESSAGE);
+                        expect(warn).toHaveBeenCalledWith(MESSAGE);
                     })
             );
         });
 
-        describe('when ts file contains "text-transform: capitalize"', () => {
+        describe('when ts file contains consumption of futile capitalize', () => {
             beforeEach(() => {
                 files = ['a.ts', 'package.json'];
                 diffForFile.mockImplementation(() =>
                     Promise.resolve({
-                        after: DIFF_CONTAINS_TEXT_TRANSFORM
+                        after: DIFF_CONTAINS_FUTILE_CAPITALIZE
                     })
                 );
             });
 
             test('should resolve', () =>
-                run(files, diffForFile, fail)
+                run(files, diffForFile, warn)
                     .then((data) => {
                         expect(data).toBe(undefined);
                     })
             );
 
-            test('should call fail with correct message', () =>
-                run(files, diffForFile, fail)
+            test('should call warn with correct message', () =>
+                run(files, diffForFile, warn)
                     .then(() => {
-                        expect(fail).toHaveBeenCalledWith(MESSAGE);
+                        expect(warn).toHaveBeenCalledWith(MESSAGE);
                     })
             );
         });
 
-        describe('when css file contains "text-transform: capitalize"', () => {
+        describe('when js file contains consumption of lodash capitalize', () => {
             beforeEach(() => {
-                files = ['a.css', 'package.json'];
+                files = ['a.js', 'package.json'];
                 diffForFile.mockImplementation(() =>
                     Promise.resolve({
-                        after: DIFF_CONTAINS_TEXT_TRANSFORM
+                        after: DIFF_CONTAINS_LODASH_CAPITALIZE
                     })
                 );
             });
 
             test('should resolve', () =>
-                run(files, diffForFile, fail)
+                run(files, diffForFile, warn)
                     .then((data) => {
                         expect(data).toBe(undefined);
                     })
             );
 
-            test('should call fail with correct message', () =>
-                run(files, diffForFile, fail)
+            test('should call warn with correct message', () =>
+                run(files, diffForFile, warn)
                     .then(() => {
-                        expect(fail).toHaveBeenCalledWith(MESSAGE);
+                        expect(warn).toHaveBeenCalledWith(MESSAGE);
                     })
             );
         });
 
-        describe('when scss file contains "text-transform: capitalize"', () => {
+        describe('when ts file contains consumption of lodash capitalize', () => {
             beforeEach(() => {
-                files = ['a.scss', 'package.json'];
+                files = ['a.ts', 'package.json'];
                 diffForFile.mockImplementation(() =>
                     Promise.resolve({
-                        after: DIFF_CONTAINS_TEXT_TRANSFORM
+                        after: DIFF_CONTAINS_LODASH_CAPITALIZE
                     })
                 );
             });
 
             test('should resolve', () =>
-                run(files, diffForFile, fail)
+                run(files, diffForFile, warn)
                     .then((data) => {
                         expect(data).toBe(undefined);
                     })
             );
 
-            test('should call fail with correct message', () =>
-                run(files, diffForFile, fail)
+            test('should call warn with correct message', () =>
+                run(files, diffForFile, warn)
                     .then(() => {
-                        expect(fail).toHaveBeenCalledWith(MESSAGE);
+                        expect(warn).toHaveBeenCalledWith(MESSAGE);
                     })
             );
         });
 
-        describe('when spec file contains "text-transform: capitalize"', () => {
+        describe('when spec file contains consumption of futile capitalize', () => {
             beforeEach(() => {
                 files = ['spec.js'];
                 diffForFile.mockImplementation(() =>
                     Promise.resolve({
-                        after: DIFF_CONTAINS_TEXT_TRANSFORM
+                        after: DIFF_CONTAINS_FUTILE_CAPITALIZE
                     })
                 );
             });
 
             test('should resolve', () =>
-                run(files, diffForFile, fail)
+                run(files, diffForFile, warn)
                     .then((data) => {
                         expect(data).toBe(undefined);
                     })
             );
 
-            test('should not call fail', () =>
-                run(files, diffForFile, fail)
+            test('should not call warn', () =>
+                run(files, diffForFile, warn)
                     .then(() => {
-                        expect(fail).not.toHaveBeenCalled();
+                        expect(warn).not.toHaveBeenCalled();
                     })
             );
         });
 
-        describe('when another file contains "text-transform: capitalize"', () => {
+        describe('when another file contains consumption of lodash capitalize', () => {
             beforeEach(() => {
                 files = ['a.json'];
                 diffForFile.mockImplementation(() =>
                     Promise.resolve({
-                        after: DIFF_CONTAINS_TEXT_TRANSFORM
+                        after: DIFF_CONTAINS_LODASH_CAPITALIZE
                     })
                 );
             });
 
             test('should resolve', () =>
-                run(files, diffForFile, fail)
+                run(files, diffForFile, warn)
                     .then((data) => {
                         expect(data).toBe(undefined);
                     })
             );
 
-            test('should not call fail', () =>
-                run(files, diffForFile, fail)
+            test('should not call warn', () =>
+                run(files, diffForFile, warn)
                     .then(() => {
-                        expect(fail).not.toHaveBeenCalled();
+                        expect(warn).not.toHaveBeenCalled();
                     })
             );
         });


### PR DESCRIPTION
Add failure if there is a file that includes `text-transform: capitalize` and warning if consumption of `capitalize` method from `futile` or `lodash` was detected as this violates the localization rules

This PR should be merged on 16-Aug (capitalization day)