### PR TITLE
[FIX] Changelog rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/dangerfile",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "⚠️ Centralised dangerfile",
   "author": "Fiverr SRE",
   "license": "MIT",

--- a/src/changelog/index.js
+++ b/src/changelog/index.js
@@ -16,7 +16,7 @@ Update changelog file with changes made in the version update.
  * @returns {Promise<undefined>}
  */
 const run = async(diffForFile, exist, warn) => {
-    const condition = await exist('package.json') && await exist('CHANGELOG.md');
+    const condition = await exist('package.json');
     if (!condition) {
     // Required files do not exist
         return;

--- a/src/changelog/spec.js
+++ b/src/changelog/spec.js
@@ -57,6 +57,7 @@ describe('changelog', () => {
     });
     describe('version was changed but not changelog', () => {
         test('should warn', async() => {
+            exist.mockImplementation((file) => Promise.resolve(file === 'package.json'));
             diffForFile.mockImplementation((file) => Promise.resolve(
                 file === 'package.json'
                     ? { before: '{"version":"1.0.0"}', after: '{"version":"1.0.1"}' }


### PR DESCRIPTION
# Why
At the moment - the changelog rule runs only if there are changes in BOTH `package.json` AND in `chagelong.md`, which is kinda weird, because it should warn if there are no changelog updates for the bumped version, no?

As far as I see - the changelog rule should run once there is a version change in the `package.json`, and if so - check for changes in the `changelog.md`

Note : `diffForFile` returns `false` if the file provided does not exist, so the changelog diffs validation is safe.